### PR TITLE
chore(types): exporting all types included in MSGReader file

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
-import MsgReader from './MsgReader'
+import MsgReader from "./MsgReader";
 
-export default MsgReader
+export * from "./MsgReader";
+
+export default MsgReader;


### PR DESCRIPTION
To give the option to use the types declared in MSGReader file, this PR exports all types included in MSGReader file